### PR TITLE
Add links to Pencil

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # FMCshapes
+
 Shapes for drawing tools to create FMC (Fundamental Modeling Concepts) diagrams
+
 * Visio: Drawing tool by Microsoft
     * Block diagram [Shapes](https://github.com/f-m-c/FMCshapes/raw/master/Visio/FMC_Block_diagram.vssx) + [Template](https://github.com/f-m-c/FMCshapes/raw/master/Visio/FMC_Block_diagram.vstx)
     * Petri net [Shapes](https://github.com/f-m-c/FMCshapes/raw/master/Visio/FMC_PetriNet_diagram.vssx) + [Template](https://github.com/f-m-c/FMCshapes/raw/master/Visio/FMC_PetriNet_diagram.vstx)
     * E/R diagram [Shapes](https://github.com/f-m-c/FMCshapes/raw/master/Visio/FMC_ER_diagram.vssx) + [Template](https://github.com/f-m-c/FMCshapes/raw/master/Visio/FMC_ER_diagram.vstx)
     * Common Annotation [Shapes](https://github.com/f-m-c/FMCshapes/raw/master/Visio/FMC_Annotations.vssx)
-* Pencil: GUI mockup tool by Evolus, Open Source
+* [Pencil](https://pencil.evolus.vn/): GUI mockup tool by Evolus, [Open Source](https://github.com/evolus/pencil)


### PR DESCRIPTION
I added links to Pencil so that people not knowing it can find it.

I additionally applied some [markdown-lint](https://github.com/DavidAnson/markdownlint) rules